### PR TITLE
Don't proxy connections to socket files

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ globalTunnel.initialize({
 });
 ```
 
-### Auto-Config
+## Auto-Config
 
 The `http_proxy` environment variable will be used if the first parameter to
 `globalTunnel.initialize` is null-ish.
@@ -172,6 +172,12 @@ The `http_proxy` environment variable will be used if the first parameter to
 process.env.http_proxy = 'http://10.0.0.1:3129';
 globalTunnel.initialize();
 ```
+
+## Retrieving proxy URL
+
+As the module does some extra job determining the proxy (including parsing the environment variables) and does some normalization (like defaulting the protocol to `http:`) it may be useful to retrieve the proxy URL used by the module.
+
+The property `globalTunnel.proxyUrl` is the URL-formatted (including the optional basic auth if provided) proxy config currently in use. It is `null` if the proxy is not currently enabled.
 
 # Compatibility
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can install this package by just executing the following:
 To make all HTTP and HTTPS connections go through an outbound HTTP proxy:
 
 ```js
-var globalTunnel = require('global-tunnel');
+var globalTunnel = require('global-tunnel-ng');
 
 globalTunnel.initialize({
   host: '10.0.0.10',

--- a/README.md
+++ b/README.md
@@ -173,11 +173,13 @@ process.env.http_proxy = 'http://10.0.0.1:3129';
 globalTunnel.initialize();
 ```
 
-## Retrieving proxy URL
+## Retrieving proxy URL and parsed config
 
 As the module does some extra job determining the proxy (including parsing the environment variables) and does some normalization (like defaulting the protocol to `http:`) it may be useful to retrieve the proxy URL used by the module.
 
 The property `globalTunnel.proxyUrl` is the URL-formatted (including the optional basic auth if provided) proxy config currently in use. It is `null` if the proxy is not currently enabled.
+
+Similarly, the `globalTunnel.proxyConfig` contains the entire parsed and normalized config.
 
 # Compatibility
 

--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ function stringifyProxy(conf) {
 
 globalTunnel.isProxying = false;
 globalTunnel.proxyUrl = null;
+globalTunnel.proxyConfig = null;
 
 function findEnvVarProxy() {
   var key, val, result;
@@ -105,6 +106,8 @@ function findEnvVarProxy() {
  * (falsy uses node's default).
  */
 globalTunnel.initialize = function(conf) {
+  // don't do anything if already proxying.
+  // To change the settings `.end()` should be called first.
   if (globalTunnel.isProxying) {
     return;
   }
@@ -125,8 +128,7 @@ globalTunnel.initialize = function(conf) {
       // nothing passed - parse from the env
       conf = tryParse(envVarProxy);
     } else {
-      globalTunnel.isProxying = false;
-      globalTunnel.proxyUrl = null;
+      // no config - do nothing
       return;
     }
 
@@ -167,6 +169,7 @@ globalTunnel.initialize = function(conf) {
 
     globalTunnel.isProxying = true;
     globalTunnel.proxyUrl = stringifyProxy(conf);
+    globalTunnel.proxyConfig = clone(conf);
   } catch (e) {
     resetGlobals();
     throw e;
@@ -276,4 +279,5 @@ globalTunnel.end = function() {
   resetGlobals();
   globalTunnel.isProxying = false;
   globalTunnel.proxyUrl = null;
+  globalTunnel.proxyConfig = null;
 };

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ exports.constructor = function globalTunnel(){};
 var http = require('http');
 var https = require('https');
 var urlParse = require('url').parse;
+var urlStringify = require('url').format;
 
 var pick = require('lodash/pick');
 var assign = require('lodash/assign');
@@ -59,15 +60,12 @@ function tryParse(url) {
 
 // Stringifies the normalized parsed config
 function stringifyProxy(conf) {
-  return [
-    conf.protocol,
-    conf.proxyAuth,
-    conf.proxyAuth ? '@' : null,
-    conf.host,
-    ':',
-    conf.port
-  ].filter(function (x) { return !!x; })
-  .join('');
+  return urlStringify({
+    protocol: conf.protocol,
+    host: conf.host,
+    port: conf.port,
+    auth: conf.proxyAuth
+  })
 }
 
 globalTunnel.isProxying = false;

--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function tryParse(url) {
 function stringifyProxy(conf) {
   return urlStringify({
     protocol: conf.protocol,
-    host: conf.host,
+    hostname: conf.host,
     port: conf.port,
     auth: conf.proxyAuth
   })

--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ globalTunnel._makeRequest = function(httpOrHttps, protocol) {
     }
 
     // Respect the default agent provided by node's lib/https.js
-    if (options.agent == null && typeof options.createConnection !== 'function') {
+    if (options.agent == null && typeof options.createConnection !== 'function' && options.host) {
       options.agent = options._defaultAgent || httpOrHttps.globalAgent;
     }
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function tryParse(url) {
     protocol: parsed.protocol,
     host: parsed.hostname,
     port: parseInt(parsed.port, 10),
-    auth: parsed.auth
+    proxyAuth: parsed.auth
   };
 }
 
@@ -92,7 +92,7 @@ globalTunnel.initialize = function(conf) {
   if (globalTunnel.isProxying) {
     return;
   }
-  
+
   try {
     // This has an effect of also removing the proxy config
     // from the global env to prevent other modules (like request) doing
@@ -141,7 +141,6 @@ globalTunnel.initialize = function(conf) {
     if (conf.httpsOptions) {
       conf.outerHttpsOpts = conf.innerHttpsOpts = conf.httpsOptions;
     }
-
 
     http.globalAgent = globalTunnel._makeAgent(conf, 'http', connectHttp);
     https.globalAgent = globalTunnel._makeAgent(conf, 'https', connectHttps);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "global-tunnel-ng",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Global HTTP & HTTPS tunneling",
   "main": "index.js",
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 var assert = require('goinstant-assert');
 var sinon = require('sinon');
 var assign = require('lodash/assign');
+var pick = require('lodash/pick');
 
 // deliberate: node and 3rd party modules before global-tunnel
 var EventEmitter = require('events').EventEmitter;
@@ -105,6 +106,38 @@ describe('global-proxy', function() {
       globalTunnel.end();
     });
   });
+
+  describe('exposed config', function() {
+    afterEach(function() {
+      globalTunnel.end();
+    });
+
+    it('has the same params as the passed config', function() {
+      var conf = { host: 'proxy.com', port: 1234, proxyAuth: 'user:pwd', protocol: 'https:' };
+      globalTunnel.initialize(conf);
+      assert.deepEqual(conf, pick(globalTunnel.proxyConfig, [
+        'host', 'port', 'proxyAuth', 'protocol'
+      ]));
+    });
+
+    it('has the expected defaults', function() {
+      var conf = { host: 'proxy.com', port: 1234, proxyAuth: 'user:pwd' };
+      globalTunnel.initialize(conf);
+      assert.equal(globalTunnel.proxyConfig.protocol, 'http:');
+    });
+  })
+
+  describe('stringified config', function() {
+    afterEach(function() {
+      globalTunnel.end();
+    });
+
+    it('has the same params as the passed config', function() {
+      var conf = { host: 'proxy.com', port: 1234, proxyAuth: 'user:pwd', protocol: 'https' };
+      globalTunnel.initialize(conf);
+      assert.equal(globalTunnel.proxyUrl, 'https://user:pwd@proxy.com:1234');
+    });
+  })
 
   function proxyEnabledTests(testParams) {
 


### PR DESCRIPTION
I discovered the problem while developing preload support in `resin-cli`:
If you set `RESINRC_PROXY` to some value, dockerode connections to `/var/run/docker.sock` would go through the proxy and fail.